### PR TITLE
Update railtie to work with Rails 3.1.

### DIFF
--- a/lib/bldr/rails/rails3.rb
+++ b/lib/bldr/rails/rails3.rb
@@ -1,7 +1,6 @@
 module ActionView
   module Template::Handlers
     class Bldr
-      self.default_format = Mime::JSON
 
       # Compile the template
       #

--- a/lib/bldr/rails/rails3.rb
+++ b/lib/bldr/rails/rails3.rb
@@ -1,9 +1,6 @@
 module ActionView
   module Template::Handlers
-
-    class Bldr < Template::Handler
-      include Compilable
-
+    class Bldr
       self.default_format = Mime::JSON
 
       # Compile the template
@@ -12,7 +9,7 @@ module ActionView
       #
       # @param [ActionView::Template] the actionview template
       # @return [String] the template string
-      def compile(template)
+      def self.call(template)
         source = template.source.inspect
         "Bldr::Engine.new(#{source}).render"
       end


### PR DESCRIPTION
This removes deprecation warnings with the ActionView template.
