### PR TITLE
Passthrough objects

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+## 0.6.0 (2012-xx-xx)
+* Feature: Add the ability to pass-through objects directly to `object` and
+  `collection` DSL methods
+
 ## 0.5.5 (2012-05-15)
 * Bug: Allow .bldr extensions at the end of partial template names
 * Bug: `#attribute` DSL method returns self, allowing use at top level

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+## 0.5.5 (2012-05-15)
+* Bug: Allow .bldr extensions at the end of partial template names
+* Bug: `#attribute` DSL method returns self, allowing use at top level
+
 ## 0.5.4 (2012-04-24)
 * Fix bug to allow using `template` method at the root of a bldr template
 * Add `locals` reader method to allow access to locals passed into a bldr template

--- a/lib/bldr/node.rb
+++ b/lib/bldr/node.rb
@@ -99,12 +99,16 @@ module Bldr
       end
 
       vals = if values
-               values.map do |item|
-                 Node.new(item, opts.merge(:parent => self), &block).result
-               end
-             else
-               []
-             end
+        if block_given?
+          values.map do |item|
+            Node.new(item, opts.merge(:parent => self), &block).result
+          end
+        else
+          values
+        end
+      else
+        []
+      end
 
       if items.respond_to?('keys')
         merge_result! key, vals

--- a/lib/bldr/node.rb
+++ b/lib/bldr/node.rb
@@ -57,6 +57,11 @@ module Bldr
     #     attributes(:url) { url }
     #   end
     #
+    # @example "Pass-through" objects
+    #   object :person => person do
+    #     object :hobbies => hobbies
+    #   end
+    #
     # @param [Hash, Nil] hash a key/value pair indicating the output key name
     #   and the object to serialize.
     # @param [Proc] block the code block to evaluate
@@ -83,6 +88,24 @@ module Bldr
       self
     end
 
+    # Build a collection of objects, either passing each object
+    # into the block provided, or rendering the collection
+    # "pass-through", i.e. exactly as it appears.
+    #
+    # @example
+    #   object :person => person do
+    #     attributes :id, :name, :age
+    #
+    #     collection :friends => person.friends do
+    #       attributes :name, :age, :friend_count
+    #     end
+    #   end
+    #
+    # @example "Pass-through" collections
+    #   object :person => person do
+    #     collection :hobbies => hobbies
+    #   end
+    #
     # @param [Array, Hash] items Either an array of items, or a hash.
     #   If an array is passed in, the objects will be rendered at the
     #   "top level", i.e. without a key pointing to them.

--- a/lib/bldr/node.rb
+++ b/lib/bldr/node.rb
@@ -83,6 +83,9 @@ module Bldr
       self
     end
 
+    # @param [Array, Hash] items Either an array of items, or a hash.
+    #   If an array is passed in, the objects will be rendered at the
+    #   "top level", i.e. without a key pointing to them.
     # @return [Bldr::Node] returns self
     def collection(items, &block)
 

--- a/lib/bldr/node.rb
+++ b/lib/bldr/node.rb
@@ -63,18 +63,23 @@ module Bldr
     #
     # @return [Bldr::Node] returns self
     def object(base = nil, &block)
-      if base.kind_of? Hash
-        key   = base.keys.first
-        value = base.values.first
+      if block_given?
+        if base.kind_of? Hash
+          key   = base.keys.first
+          value = base.values.first
+        else
+          key = base
+          value = nil
+        end
+
+        return nil if value.nil? and base.kind_of? Hash
+
+        node  = Node.new(value, opts.merge(:parent => self), &block)
+        merge_result!(key, node.result)
       else
-        key = base
-        value = nil
+        merge_result!(nil, base)
       end
 
-      return nil if value.nil? and base.kind_of? Hash
-      node  = Node.new(value, opts.merge(:parent => self), &block)
-      merge_result!(key, node.result)
-      
       self
     end
 

--- a/lib/bldr/node.rb
+++ b/lib/bldr/node.rb
@@ -89,6 +89,7 @@ module Bldr
     # @return [Bldr::Node] returns self
     def collection(items, &block)
 
+      # Does this collection live in a key, or is it top-level?
       if items.respond_to?('keys')
         key = items.keys.first
         values = items.values.to_a.first
@@ -96,9 +97,11 @@ module Bldr
         key = nil
         values = items
       end
-      
+
       vals = if values
-               values.map{|item| Node.new(item, opts.merge(:parent => self), &block).result}
+               values.map do |item|
+                 Node.new(item, opts.merge(:parent => self), &block).result
+               end
              else
                []
              end

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -415,6 +415,30 @@ describe "Node#to_json" do
 end
 
 describe "Node#collection" do
+  context "when passed an object with no block" do
+    it "renders the object exactly as it exists" do
+      coll = [{'key' => 'val'}]
+      node = node_wrap do
+        collection coll
+      end
+
+      node.result.should == coll
+    end
+
+    it "renders complex collection objects correctly" do
+      hobbies = [{'name' => "Gym"}, {'name' => "Tan"}, {'name' => "Laundry"}]
+
+      node = node_wrap do
+        object 'person' => Person.new("Alex") do
+          attribute :name
+          collection 'hobbies' => hobbies
+        end
+      end
+
+      node.result.should == {'person' => {:name => "Alex", 'hobbies' => hobbies}}
+    end
+  end
+
   it "iterates through the collection and renders them as nodes" do
     node = node_wrap do
       object :person => Person.new('alex', 26) do

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -18,6 +18,15 @@ describe "Node#attributes" do
 end
 
 describe "Node#object" do
+  context "rendering an object exactly as it exists" do
+    it "renders the object exactly as it appears when passed an object with no block" do
+      obj = {'key' => 'val', 'nested' => {'key' => 'val'}}
+      node = node_wrap do
+        object obj
+      end
+      node.result.should == obj
+    end
+  end
 
   context "a zero arg root object node" do
 


### PR DESCRIPTION
This adds support for passing objects directly to the `object` and `collection` methods, and having them rendered exactly as they are. This assumes that these objects can be rendered in their entirety by a json encoder, which means that the objects contain only "native" values.
