### PR TITLE
Add access to instance variables from within nested blocks

### DIFF
--- a/lib/bldr/node.rb
+++ b/lib/bldr/node.rb
@@ -3,6 +3,8 @@ module Bldr
 
   class Node
 
+    PROTECTED_IVARS = [:@parent, :@opts, :@current_object, :@views, :@locals, :@result]
+
     attr_reader :current_object, :result, :parent, :opts, :views, :locals
 
     # Initialize a new Node instance.
@@ -24,7 +26,9 @@ module Bldr
       @views          = opts[:views]
       @locals         = opts[:locals]
       # Storage hash for all descendant nodes
-      @result  = {}
+      @result         = {}
+
+      copy_instance_variables_from(opts[:parent]) if opts[:parent]
 
       instance_eval(&block) if block_given?
     end
@@ -243,6 +247,17 @@ module Bldr
     end
 
     private
+
+    # Retrieves all instance variables from an object and sets them in the
+    #   current scope.
+    #
+    # @param [Object] object The object to copy instance variables from.
+    def copy_instance_variables_from(object)
+      ivar_names = (object.instance_variables - PROTECTED_IVARS).map(&:to_s)
+      ivar_names.map do |name|
+        instance_variable_set(name, object.instance_variable_get(name))
+      end
+    end
 
     # Determines if an object was passed in with a key pointing to it, or if
     # it was passed in as the "root" of the current object. Essentially, this

--- a/lib/bldr/node.rb
+++ b/lib/bldr/node.rb
@@ -3,7 +3,7 @@ module Bldr
 
   class Node
 
-    PROTECTED_IVARS = [:@parent, :@opts, :@current_object, :@views, :@locals, :@result]
+    PROTECTED_IVARS = [:@current_object, :@result, :@parent, :@opts, :@views, :@locals]
 
     attr_reader :current_object, :result, :parent, :opts, :views, :locals
 

--- a/spec/fixtures/nested_ivars.bldr
+++ b/spec/fixtures/nested_ivars.bldr
@@ -1,0 +1,5 @@
+object nil do
+  object :person => @person do
+    attributes :name, :age
+  end
+end

--- a/spec/integration/sinatra_spec.rb
+++ b/spec/integration/sinatra_spec.rb
@@ -60,10 +60,20 @@ describe "Using Bldr with a sinatra app" do
       @person = Person.new('bert', 99)
       bldr :'fixtures/ivar'
     end
+
+    get '/nested_ivars' do
+      @person = Person.new('bert', 99)
+      bldr :'fixtures/nested_ivars'
+    end
   end
 
   it 'passes ivars through to the template' do
     response = Rack::MockRequest.new(TestApp).get('/ivar')
+    decode(response.body).should == {'person' => {'name' => 'bert', 'age' => 99}}
+  end
+
+  it 'makes ivars available in nested objects' do
+    response = Rack::MockRequest.new(TestApp).get('/nested_ivars')
     decode(response.body).should == {'person' => {'name' => 'bert', 'age' => 99}}
   end
 


### PR DESCRIPTION
#### This PR
- Copies instance variables from a parent node when a new node is created that has a parent so that nested blocks have access to the instance variables.
  - Not all instance variables are copied into the child's context, specifically instance variables sharing a name used in the `attr_reader` helper.
#### Gotcha

``` ruby
object :user => @user do
  # Raises an error unless @user has @bar as an instance variable
  #   since this block is instance_eval'd on current_object, which
  #   in this case is @user.
  attribute(:bad_foo) { @bar }

  # Workaround; the block is simply call'd with current_object as 
  #   the one and only parameter which in this case we don't care
  #   about so can set to _.
  attribute(:good_foo) { |_| @bar }
end
```
