### PR TITLE
0.7.0 Release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 rvm:
   - 1.9.3
-  - ree
   - ruby-head
-  - rbx-18mode
   - rbx-19mode

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,5 @@
 ## 0.7.0 (2013-xx-xx)
-* Support for inherited instance variablesq
+* Support for inherited instance variables
 * Breaking change: Node#attribute block syntax no longer inherits
   context from current_object. See 941608e7 for more
 * Breaking change: Drop ruby 1.8 support

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,10 @@
-## 0.6.1 (2013-02-18)
+## 0.7.0 (2013-xx-xx)
+* Support for inherited instance variablesq
+* Breaking change: Node#attribute block syntax no longer inherits
+  context from current_object. See 941608e7 for more
+* Breaking change: Drop ruby 1.8 support
+
+## 0.6.1 (2013-02-18) -- yanked
 * Feature: Add the ability to access instance variables set in sinatra
   actions in bldr templates.
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,75 @@ end
 
 See the [Documentation & Examples](https://github.com/ajsharp/bldr/wiki/Documentation-&-Examples) page on the wiki.
 
+## Deprecations & Breaking Changes
+
+### 0.7.0: current_object deprecation
+
+The use of `current_object` is now deprecated. Instead of referencing `current_object` in bldr templates
+use block variables in `object` and `collection` methods:
+
+```ruby
+# OLD (deprecated)
+collection :people => people do
+  attribute(:name) { current_object.name }
+end
+
+# NEW
+collection :people => people do |person|
+  attribute(:name) { person.name }
+end
+```
+
+Make use of block variables the same way for the `object` method:
+
+```ruby
+# OLD (deprecated)
+object :person => person do
+  attributes :name, :age
+
+  person = current_object
+  object :address => person.address do
+    # current_object here would be assigned to person.address
+    attribute(:zip) { current_object.zip_code }
+    attribute(:address_title) { person.display_name }
+  end
+end
+
+# NEW
+object :person => person do |person|
+  attributes :name, :age
+
+  object :adress => person.address do |address|
+    attribute(:zip) { address.zip_code }
+    attribute(:address_title) { person.display_name }
+  end
+end
+```
+
+### 0.7.0: attribute method breaking change
+
+One of the forms of the `attribute` method has changed in the 0.7.0 release.
+Previously, using the dynamic block form of `attribute`, if you did not pass
+in a block variable, the block would be eval'd in context of the `current_object`.
+This behavior fails the "principle of least surprise" test.
+
+0.7.0 changes this behavior by simply executing the block in context of `Bldr::Node`, which provides
+access to instance variables and locals available in that context.
+
+```ruby
+# OLD
+object :person => person do
+  attribute(:name) { display_name } # equivalent to doing attribute(:name) { |person| person.display_name }
+end
+
+# NEW
+object :person => @person do
+  attribute(:name) { @person.display_name }
+end
+```
+
+See [941608e](https://github.com/ajsharp/bldr/commit/d0bfbd8) and [d0bfbd8](https://github.com/ajsharp/bldr/commit/d0bfbd8) for more info.
+
 ## Editor Syntax Support
 
 To get proper syntax highlighting in vim, add this line to your .vimrc:

--- a/lib/bldr/node.rb
+++ b/lib/bldr/node.rb
@@ -3,6 +3,8 @@ module Bldr
 
   class Node
 
+    PROTECTED_IVARS = [:@parent, :@opts, :@current_object, :@views, :@locals, :@result]
+
     attr_reader :current_object, :result, :parent, :opts, :views, :locals
 
     # Initialize a new Node instance.
@@ -24,7 +26,9 @@ module Bldr
       @views          = opts[:views]
       @locals         = opts[:locals]
       # Storage hash for all descendant nodes
-      @result  = {}
+      @result         = {}
+
+      copy_instance_variables_from(opts[:parent]) if opts[:parent]
 
       instance_eval(&block) if block_given?
     end
@@ -243,6 +247,17 @@ module Bldr
     end
 
     private
+
+    # Retrieves all instance variables from an object and sets them in the
+    #   current scope.
+    #
+    # @param [Object] object The object to copy instance variables from.
+    def copy_instance_variables_from(object)
+      ivar_names = (object.instance_variables - PROTECTED_IVARS).map(&:to_s)
+      ivar_names.map do |name|
+        instance_variable_set(name, object.instance_variable_get(name))
+      end
+    end
 
     # Determines if an object was passed in with a key pointing to it, or if
     # it was passed in as the "root" of the current object. Essentially, this

--- a/lib/bldr/node.rb
+++ b/lib/bldr/node.rb
@@ -32,7 +32,13 @@ module Bldr
 
       copy_instance_variables_from(opts[:parent]) if opts[:parent]
 
-      instance_eval(&block) if block_given?
+      if block_given?
+        if value && block.arity > 0
+          instance_exec(value, &block)
+        else
+          instance_eval(&block)
+        end
+      end
     end
 
     # Create and render a node.

--- a/lib/bldr/node.rb
+++ b/lib/bldr/node.rb
@@ -19,6 +19,8 @@ module Bldr
     #
     #
     # @param [Object] value an object to serialize.
+    # @param [Hash] opts
+    # @option [Object] opts :parent used to copy instance variables into self
     def initialize(value = nil, opts = {}, &block)
       @current_object = value
       @opts           = opts

--- a/lib/bldr/node.rb
+++ b/lib/bldr/node.rb
@@ -204,7 +204,7 @@ module Bldr
       if block_given?
         raise(ArgumentError, "You may only pass one argument to #attribute when using the block syntax.") if args.size > 1
         raise(ArgumentError, "You cannot use a block of arity > 0 if current_object is not present.") if block.arity > 0 and current_object.nil?
-        merge_result!(args.first, (block.arity == 1) ? block.call(current_object) : current_object.instance_eval(&block))
+        merge_result! args.first, block.call(current_object)
       else
         case args.size
         when 1 # inferred object

--- a/lib/bldr/node.rb
+++ b/lib/bldr/node.rb
@@ -41,6 +41,11 @@ module Bldr
       end
     end
 
+    def current_object
+      warn "[DEPRECATION] `current_object` is deprecated. Please use object or collection block varibles instead."
+      @current_object
+    end
+
     # Create and render a node.
     #
     # @example A keyed object
@@ -194,15 +199,15 @@ module Bldr
     #
     # @return [Nil]
     def attributes(*args, &block)
-      if current_object.nil?
+      if @current_object.nil?
         raise(ArgumentError, "No current_object to apply #attributes to.")
       end
 
       args.each do |arg|
         if arg.is_a?(Hash)
-          merge_result!(arg.keys.first, current_object.send(arg.values.first))
+          merge_result!(arg.keys.first, @current_object.send(arg.values.first))
         else
-          merge_result!(arg, current_object.send(arg))
+          merge_result!(arg, @current_object.send(arg))
         end
       end
       self
@@ -211,20 +216,20 @@ module Bldr
     def attribute(*args,&block)
       if block_given?
         raise(ArgumentError, "You may only pass one argument to #attribute when using the block syntax.") if args.size > 1
-        raise(ArgumentError, "You cannot use a block of arity > 0 if current_object is not present.") if block.arity > 0 and current_object.nil?
+        raise(ArgumentError, "You cannot use a block of arity > 0 if current_object is not present.") if block.arity > 0 and @current_object.nil?
         if block.arity > 0
-          merge_result! args.first, block.call(current_object)
+          merge_result! args.first, block.call(@current_object)
         else
           merge_result! args.first, block.call
         end
       else
         case args.size
         when 1 # inferred object
-          raise(ArgumentError, "#attribute can't be used when there is no current_object.") if current_object.nil?
+          raise(ArgumentError, "#attribute can't be used when there is no current_object.") if @current_object.nil?
           if args[0].is_a?(Hash)
-            merge_result!(args[0].keys.first, current_object.send(args[0].values.first))
+            merge_result!(args[0].keys.first, @current_object.send(args[0].values.first))
           else
-            merge_result!(args[0], current_object.send(args[0]))
+            merge_result!(args[0], @current_object.send(args[0]))
           end
         when 2 # static property
           merge_result!(args[0], args[1])

--- a/lib/bldr/node.rb
+++ b/lib/bldr/node.rb
@@ -3,7 +3,7 @@ module Bldr
 
   class Node
 
-    PROTECTED_IVARS = [:@parent, :@opts, :@current_object, :@views, :@locals, :@result]
+    PROTECTED_IVARS = [:@current_object, :@result, :@parent, :@opts, :@views, :@locals]
 
     attr_reader :current_object, :result, :parent, :opts, :views, :locals
 

--- a/lib/bldr/node.rb
+++ b/lib/bldr/node.rb
@@ -34,7 +34,7 @@ module Bldr
 
       instance_eval(&block) if block_given?
     end
-    
+
     # Create and render a node.
     #
     # @example A keyed object
@@ -206,7 +206,11 @@ module Bldr
       if block_given?
         raise(ArgumentError, "You may only pass one argument to #attribute when using the block syntax.") if args.size > 1
         raise(ArgumentError, "You cannot use a block of arity > 0 if current_object is not present.") if block.arity > 0 and current_object.nil?
-        merge_result! args.first, block.call(current_object)
+        if block.arity > 0
+          merge_result! args.first, block.call(current_object)
+        else
+          merge_result! args.first, block.call
+        end
       else
         case args.size
         when 1 # inferred object

--- a/lib/bldr/template.rb
+++ b/lib/bldr/template.rb
@@ -2,6 +2,7 @@ require 'tilt'
 
 module Bldr
 
+  # This class is required for Tilt compatibility
   class Template < Tilt::Template
 
     self.default_mime_type = 'application/json'
@@ -14,6 +15,8 @@ module Bldr
       defined? ::Bldr
     end
 
+    # Called at the end of Tilt::Template#initialize.
+    # Use this method to access or mutate any state available to Tilt::Template
     def prepare
       # We get NotImplementedError by Tilt when we don't have this method
     end

--- a/lib/sinatra/bldr.rb
+++ b/lib/sinatra/bldr.rb
@@ -28,8 +28,8 @@ module Sinatra
 
         locals = opts.delete(:locals) || {}
 
-        MultiJson.encode render(:bldr, template, opts, locals, &block).result    
         # @todo add support for alternate formats, like plist
+        MultiJson.encode render(:bldr, template, opts, locals, &block).result
       end
     end
 

--- a/lib/sinatra/bldr.rb
+++ b/lib/sinatra/bldr.rb
@@ -28,8 +28,9 @@ module Sinatra
         locals = opts.delete(:locals) || {}
 
         # copy local instance_variables to template
-        instance_variables.map(&:to_s).each { |var| locals[var] = instance_variable_get(var) }
+        instance_variables.map(&:to_s).each { |var| opts[:scope].instance_variable_set(var, instance_variable_get(var)) }
 
+        # render returns a `Bldr::Node` instance
         MultiJson.encode render(:bldr, template, opts, locals, &block).result    
         # @todo add support for alternate formats, like plist
       end

--- a/lib/sinatra/bldr.rb
+++ b/lib/sinatra/bldr.rb
@@ -23,12 +23,10 @@ module Sinatra
       # @param [Hash] opts a hash of options
       # @option opts [Hash] :locals a hash of local variables to be used in the template
       def bldr(template, opts = {}, &block)
+        opts[:parent] = self
         opts[:scope] = ::Bldr::Node.new(nil, opts.merge(:views => (settings.views || "./views")))
 
         locals = opts.delete(:locals) || {}
-
-        # copy local instance_variables to template
-        instance_variables.map(&:to_s).each { |var| locals[var] = instance_variable_get(var) }
 
         MultiJson.encode render(:bldr, template, opts, locals, &block).result    
         # @todo add support for alternate formats, like plist

--- a/spec/fixtures/nested_ivars.bldr
+++ b/spec/fixtures/nested_ivars.bldr
@@ -1,0 +1,5 @@
+object nil do
+  object :person => @person do
+    attributes :name, :age
+  end
+end

--- a/spec/fixtures/nested_objects.json.bldr
+++ b/spec/fixtures/nested_objects.json.bldr
@@ -1,8 +1,8 @@
 
 object :person => bert do
   attributes :name, :age
-  attribute :name_age do
-    "#{name} #{age}"
+  attribute :name_age do |person|
+    "#{person.name} #{person.age}"
   end
 
   object :friend => ernie do

--- a/spec/functional/tilt_template_spec.rb
+++ b/spec/functional/tilt_template_spec.rb
@@ -1,5 +1,38 @@
 require 'spec_helper'
 
+module Bldr
+  describe "instance variables" do
+    let(:ctx) { Object.new }
+    it 'has access to ivars in attribute blocks with no arity' do
+      ctx.instance_variable_set(:@person, Person.new('john denver'))
+
+      Template.new {
+        <<-RUBY
+         object :person do
+           attribute(:name) { @person.name }
+         end
+        RUBY
+      }.render(Node.new(nil, :parent => ctx))
+        .result
+        .should == {:person => {:name => 'john denver'}}
+    end
+
+    it 'has access to ivars in attribute blocks with arity of 1' do
+      ctx.instance_variable_set(:@denver, Person.new('john denver'))
+      ctx.instance_variable_set(:@rich, Person.new('charlie rich'))
+      Template.new {
+        <<-RUBY
+         object :person => @denver do
+           attribute(:name) { |p| @rich.name }
+         end
+        RUBY
+      }.render(Node.new(nil, :parent => ctx))
+        .result
+        .should == {:person => {:name => 'charlie rich'}}
+    end
+  end
+end
+
 describe "evaluating a tilt template" do
   it "registers with Tilt" do
     Tilt['test.bldr'].should == Bldr::Template

--- a/spec/functional/tilt_template_spec.rb
+++ b/spec/functional/tilt_template_spec.rb
@@ -4,6 +4,22 @@ module Bldr
   describe "instance variables" do
     let(:ctx) { Object.new }
 
+    describe "collection blocks" do
+      it 'has access to instance variables' do
+        ctx.instance_variable_set(:@person, Person.new("John Denver"))
+
+        Template.new do
+          <<-RUBY
+            collection :artists => [@person] do
+              attribute(:name) { @person.name }
+            end
+          RUBY
+        end.render(Node.new(nil, :parent => ctx))
+        .result
+        .should == {:artists => [{:name => 'John Denver'}]}
+      end
+    end
+
     it 'has access to instance variables in include template partials' do
       ctx.instance_variable_set(:@person, Person.new('john denver'))
 

--- a/spec/functional/tilt_template_spec.rb
+++ b/spec/functional/tilt_template_spec.rb
@@ -185,9 +185,9 @@ module Bldr
       it "returns json for a root collection with embedded collection template" do
         tpl = Bldr::Template.new {
         <<-RUBY
-          collection :people => people do
+          collection :people => people do |person|
             attributes :name, :age
-            collection :friends => current_object.friends do
+            collection :friends => person.friends do
               attributes :name, :age
             end
           end

--- a/spec/functional/tilt_template_spec.rb
+++ b/spec/functional/tilt_template_spec.rb
@@ -1,6 +1,23 @@
 require 'spec_helper'
 
 module Bldr
+  describe 'local variable access' do
+    it 'provides access to locals in nested object blocks' do
+      Template.new do
+          <<-RUBY
+            object :person => person do
+              attribute(:name) { person.name }
+              object :address => Object.new do |address|
+                attribute(:display_name) { person.name }
+              end
+            end
+          RUBY
+      end.render(Node.new(nil), {person: Person.new('alex')})
+      .result
+      .should == {:person => {:name => 'alex', :address => {:display_name => 'alex'}}}
+    end
+  end
+
   describe "instance variables" do
     let(:ctx) { Object.new }
 

--- a/spec/functional/tilt_template_spec.rb
+++ b/spec/functional/tilt_template_spec.rb
@@ -3,6 +3,19 @@ require 'spec_helper'
 module Bldr
   describe "instance variables" do
     let(:ctx) { Object.new }
+
+    it 'has access to instance variables in include template partials' do
+      ctx.instance_variable_set(:@person, Person.new('john denver'))
+
+      Template.new {
+        <<-RUBY
+         template('spec/fixtures/ivar.bldr')
+        RUBY
+      }.render(Node.new(nil, :parent => ctx))
+      .result
+      .should == {:person => {:name => 'john denver', :age => nil}}
+    end
+
     it 'has access to ivars in attribute blocks with no arity' do
       ctx.instance_variable_set(:@person, Person.new('john denver'))
 

--- a/spec/functional/tilt_template_spec.rb
+++ b/spec/functional/tilt_template_spec.rb
@@ -13,8 +13,8 @@ module Bldr
          end
         RUBY
       }.render(Node.new(nil, :parent => ctx))
-        .result
-        .should == {:person => {:name => 'john denver'}}
+      .result
+      .should == {:person => {:name => 'john denver'}}
     end
 
     it 'has access to ivars in attribute blocks with arity of 1' do
@@ -27,82 +27,82 @@ module Bldr
          end
         RUBY
       }.render(Node.new(nil, :parent => ctx))
-        .result
-        .should == {:person => {:name => 'charlie rich'}}
+      .result
+      .should == {:person => {:name => 'charlie rich'}}
     end
   end
-end
 
-describe "evaluating a tilt template" do
-  it "registers with Tilt" do
-    Tilt['test.bldr'].should == Bldr::Template
-  end
 
-  it "renders a template" do
-    alex = Person.new
-    alex.name = 'alex'
+  describe "evaluating a tilt template" do
+    it "registers with Tilt" do
+      Tilt['test.bldr'].should == Bldr::Template
+    end
 
-    tpl = Bldr::Template.new { "object(:person => alex) { attribute(:name) }" }
-    tpl.render(Bldr::Node.new, :alex => alex).result.should == {:person => {:name => 'alex'}}
-  end
+    it "renders a template" do
+      alex = Person.new
+      alex.name = 'alex'
 
-  it "allows attribute to be used at the root-level" do
-    tpl = Bldr::Template.new {
+      tpl = Bldr::Template.new { "object(:person => alex) { attribute(:name) }" }
+      tpl.render(Bldr::Node.new, :alex => alex).result.should == {:person => {:name => 'alex'}}
+    end
+
+    it "allows attribute to be used at the root-level" do
+      tpl = Bldr::Template.new {
       <<-RUBY
         attribute(:foo) { "bar" }
       RUBY
-    }
-    tpl.render(Bldr::Node.new(nil)).result.should == {:foo => 'bar'}
-  end
+      }
+      tpl.render(Bldr::Node.new(nil)).result.should == {:foo => 'bar'}
+    end
 
-  it "works when render two top-level objects" do
-    alex = Person.new('alex')
-    john = Person.new('john')
+    it "works when render two top-level objects" do
+      alex = Person.new('alex')
+      john = Person.new('john')
 
-    tpl = Bldr::Template.new {
+      tpl = Bldr::Template.new {
       <<-RUBY
         object(:person_1 => alex) { attribute(:name) }
         object(:person_2 => john) { attribute(:name) }
       RUBY
-    }
+      }
 
-    result = tpl.render(Bldr::Node.new, :alex => alex, :john => john).result
-    result.should == {
-      :person_1 => {:name => 'alex'},
-      :person_2 => {:name => 'john'}
-    }
-  end
+      result = tpl.render(Bldr::Node.new, :alex => alex, :john => john).result
+      result.should == {
+                        :person_1 => {:name => 'alex'},
+                        :person_2 => {:name => 'john'}
+                       }
+    end
 
-  it "renders nil -> null correctly" do
-    alex = Person.new('alex')
-    tpl = Bldr::Template.new {
+    it "renders nil -> null correctly" do
+      alex = Person.new('alex')
+      tpl = Bldr::Template.new {
       <<-RUBY
         object(:person_1 => alex) { attributes(:age) }
       RUBY
-    }
-    result = tpl.render(Bldr::Node.new, :alex => alex).result
-    result.should == {:person_1 => {:age => nil}}
-  end
+      }
+      result = tpl.render(Bldr::Node.new, :alex => alex).result
+      result.should == {:person_1 => {:age => nil}}
+    end
 
-  describe "root Object nodes" do
+    describe "root Object nodes" do
 
-    let(:alex) { Person.new('alex', 25) }
-    let(:ian) { Person.new('ian', 32) }
+      let(:alex) { Person.new('alex', 25) }
+      let(:ian) { Person.new('ian', 32) }
 
-    it "returns json for a root object" do
-      tpl = Bldr::Template.new {
+      it "returns json for a root object" do
+        tpl = Bldr::Template.new {
         <<-RUBY
           object :person => alex do
             attributes :name, :age
           end
         RUBY
-      }
-      result = tpl.render(Bldr::Node.new, :alex => alex, :ian => ian).result
-      result.should == {:person => {:name => 'alex', :age => 25}}
-    end
+        }
+        result = tpl.render(Bldr::Node.new, :alex => alex, :ian => ian).result
+        result.should == {:person => {:name => 'alex', :age => 25}}
+      end
 
-    it "returns json for root object templates with nested collections" do
-      tpl = Bldr::Template.new {
+      it "returns json for root object templates with nested collections" do
+        tpl = Bldr::Template.new {
         <<-RUBY
           object :person => alex do
             attributes :name, :age
@@ -112,49 +112,49 @@ describe "evaluating a tilt template" do
             end
           end
         RUBY
-      }
-      result = tpl.render(Bldr::Node.new, :alex => alex, :friends => [ian]).result
-      result.should == {
-        :person=> {:name => 'alex', :age => 25, :friends => [{:name => 'ian', :age => 32}]}
-      }
-    end
+        }
+        result = tpl.render(Bldr::Node.new, :alex => alex, :friends => [ian]).result
+        result.should == {
+                          :person=> {:name => 'alex', :age => 25, :friends => [{:name => 'ian', :age => 32}]}
+                         }
+      end
 
-    it "renders nil -> null correctly" do
-      alex = Person.new('alex')
-      tpl = Bldr::Template.new {
+      it "renders nil -> null correctly" do
+        alex = Person.new('alex')
+        tpl = Bldr::Template.new {
         <<-RUBY
           object :person_1 => alex do
             attributes(:age)
           end
         RUBY
-      }
-      result = tpl.render(Bldr::Node.new, :alex => alex).result
-      result.should == {:person_1 => {:age => nil}}
+        }
+        result = tpl.render(Bldr::Node.new, :alex => alex).result
+        result.should == {:person_1 => {:age => nil}}
+      end
+
     end
 
-  end
+    describe "root Collection nodes" do
 
-  describe "root Collection nodes" do
+      let(:alex) { Person.new('alex', 25, [Person.new('bo',33)]) }
+      let(:ian) { Person.new('ian', 32, [Person.new('eric',34)]) }
 
-    let(:alex) { Person.new('alex', 25, [Person.new('bo',33)]) }
-    let(:ian) { Person.new('ian', 32, [Person.new('eric',34)]) }
-
-    it "returns json for a root collection template" do
-      tpl = Bldr::Template.new {
+      it "returns json for a root collection template" do
+        tpl = Bldr::Template.new {
         <<-RUBY
           collection :people => people do
             attributes :name, :age
           end
         RUBY
-      }
-      result = tpl.render(Bldr::Node.new, :people => [alex,ian]).result
-      result.should == {
-        :people => [{:name => 'alex', :age => 25}, {:name => 'ian', :age => 32}]
-      }
-    end
+        }
+        result = tpl.render(Bldr::Node.new, :people => [alex,ian]).result
+        result.should == {
+                          :people => [{:name => 'alex', :age => 25}, {:name => 'ian', :age => 32}]
+                         }
+      end
 
-    it "returns json for a root collection with embedded collection template" do
-      tpl = Bldr::Template.new {
+      it "returns json for a root collection with embedded collection template" do
+        tpl = Bldr::Template.new {
         <<-RUBY
           collection :people => people do
             attributes :name, :age
@@ -163,27 +163,28 @@ describe "evaluating a tilt template" do
             end
           end
         RUBY
-      }
-      result = tpl.render(Bldr::Node.new, :people => [alex,ian]).result
-      result.should == {
-        :people=> [{
-          :name => 'alex',
-          :age => 25,
-          :friends => [{:name => 'bo', :age => 33}]
-        },{
-          :name => 'ian',
-          :age => 32,
-          :friends => [{:name => 'eric', :age => 34}]
-        }]
-      }
+        }
+        result = tpl.render(Bldr::Node.new, :people => [alex,ian]).result
+        result.should == {
+                          :people=> [{
+                                      :name => 'alex',
+                                      :age => 25,
+                                      :friends => [{:name => 'bo', :age => 33}]
+                                     },{
+                                        :name => 'ian',
+                                        :age => 32,
+                                        :friends => [{:name => 'eric', :age => 34}]
+                                       }]
+                         }
+      end
+
     end
-
   end
-end
 
-describe "using a partial template at the root of another template" do
-  it "works as expected" do
-    template = Bldr::Template.new('./spec/fixtures/root_partial.bldr')
-    template.render(Bldr::Node.new(nil, :views => './spec')).result.should == {:foo => 'bar'}
+  describe "using a partial template at the root of another template" do
+    it "works as expected" do
+      template = Bldr::Template.new('./spec/fixtures/root_partial.bldr')
+      template.render(Bldr::Node.new(nil, :views => './spec')).result.should == {:foo => 'bar'}
+    end
   end
 end

--- a/spec/functional/tilt_template_spec.rb
+++ b/spec/functional/tilt_template_spec.rb
@@ -37,7 +37,7 @@ module Bldr
       end
     end
 
-    it 'has access to instance variables in include template partials' do
+    it 'has access to instance variables in included template partials' do
       ctx.instance_variable_set(:@person, Person.new('john denver'))
 
       Template.new {
@@ -75,6 +75,24 @@ module Bldr
       }.render(Node.new(nil, :parent => ctx))
       .result
       .should == {:person => {:name => 'charlie rich'}}
+    end
+
+    it 'has access to ivars in nested object blocks' do
+      ctx.instance_variable_set(:@batman, Person.new('batman'))
+      ctx.instance_variable_set(:@bane, Person.new('bane'))
+      Template.new {
+        <<-RUBY
+         object :hero => @batman do
+           attribute(:name) { @batman.name }
+           object :nemesis do
+             attribute(:name) { @bane.name }
+             attribute(:nemesis_name) { @batman.name }
+           end
+         end
+        RUBY
+      }.render(Node.new(nil, :parent => ctx))
+      .result
+      .should == {hero: {name: 'batman', nemesis: {name: 'bane', nemesis_name: 'batman'}}}
     end
   end
 

--- a/spec/integration/sinatra_spec.rb
+++ b/spec/integration/sinatra_spec.rb
@@ -60,10 +60,20 @@ describe "Using Bldr with a sinatra app" do
       @person = Person.new('bert', 99)
       bldr :'fixtures/ivar'
     end
+
+    get '/nested_ivars' do
+      @person = Person.new('bert', 99)
+      bldr :'fixtures/nested_ivars'
+    end
   end
 
   it 'passes ivars through to the template' do
     response = Rack::MockRequest.new(TestApp).get('/ivar')
+    decode(response.body).should == {'person' => {'name' => 'bert', 'age' => 99}}
+  end
+
+  it 'makes ivars available in nested objects' do
+    response = Rack::MockRequest.new(TestApp).get('/nested_ivars')
     decode(response.body).should == {'person' => {'name' => 'bert', 'age' => 99}}
   end
 

--- a/spec/models/song.rb
+++ b/spec/models/song.rb
@@ -1,0 +1,6 @@
+class Song
+  attr_accessor :name
+  def initialize(name)
+    @name = name
+  end
+end

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -74,7 +74,6 @@ module Bldr
       end
 
       it "renders 1 argument hash to the inferred object as the different key" do
-        # @todo remove this behavior -- it's unexpected and confusing
         node = Node.new do
           object :person => Person.new('alex', 25) do
             attribute(:fake => :name)

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -1,252 +1,119 @@
 require 'spec_helper'
 
 ERROR_MESSAGES = { :attribute_lambda_one_argument              => "You may only pass one argument to #attribute when using the block syntax.",
-                   :attribute_inferred_missing_one_argument    => "#attribute can't be used when there is no current_object.",
-                   :attribute_more_than_two_arg                => "You cannot pass more than two arguments to #attribute.",
-                   :attribute_inferred_missing_arity_too_large => "You cannot use a block of arity > 0 if current_object is not present.",
-                   :attributes_inferred_missing                => "No current_object to apply #attributes to." }
+                  :attribute_inferred_missing_one_argument    => "#attribute can't be used when there is no current_object.",
+                  :attribute_more_than_two_arg                => "You cannot pass more than two arguments to #attribute.",
+                  :attribute_inferred_missing_arity_too_large => "You cannot use a block of arity > 0 if current_object is not present.",
+                  :attributes_inferred_missing                => "No current_object to apply #attributes to." }
+module Bldr
+  describe Node, "#attributes" do
+    let(:person) {
+      Person.new('john', 25)
+    }
+    let(:node) { Bldr::Node.new(person) }
 
-describe "Node#attributes" do
-  let(:person) {
-    Person.new('john', 25)
-  }
-  let(:node) { Bldr::Node.new(person) }
-
-  it "returns stuff" do
-    node.attribute(:age).should == node
-  end
-end
-
-describe "Node#object" do
-  context "rendering an object exactly as it exists" do
-    it "renders the object exactly as it appears when passed an object with no block" do
-      obj = {'key' => 'val', 'nested' => {'key' => 'val'}}
-      node = node_wrap do
-        object obj
-      end
-      node.result.should == obj
+    it "returns stuff" do
+      node.attribute(:age).should == node
     end
   end
 
-  context "a zero arg root object node" do
-
-    def wrap(&block)
-      Bldr::Node.new do
-        object(&block)
-      end
+  describe Node, "#attribute" do
+    it "raises an exception when passed more than one argument and a block" do
+      expect {
+        Node.new {
+          attribute(:one, :two) do |person|
+            "..."
+          end
+        }
+      }.to raise_error(ArgumentError, ERROR_MESSAGES[:attribute_lambda_one_argument])
     end
 
-    describe "#attribute" do
-      it "errors on a single argument" do
-        expect {
-          node_wrap {
-            attribute(:one, :two) do |person|
-              "..."
-            end
-          }
-        }.to raise_error(ArgumentError, ERROR_MESSAGES[:attribute_lambda_one_argument])
-      end
+    it "raises an exception when passed more than two args" do
+      expect {
+        Node.new {
+          attribute(:one, :two, :three)
+        }
+      }.to raise_error(ArgumentError, ERROR_MESSAGES[:attribute_more_than_two_arg])
+    end
 
-      it "errors on 3 arguments" do
-        expect {
-          node_wrap {
-            attribute(:one, :two, :three)
-          }
-        }.to raise_error(ArgumentError, ERROR_MESSAGES[:attribute_more_than_two_arg])
-      end
+    it "errors on 1 argument since there is no inferred object" do
+      expect {
+        Node.new {
+          attribute(:one)
+        }
+      }.to raise_error(ArgumentError, ERROR_MESSAGES[:attribute_inferred_missing_one_argument])
+    end
 
-      it "errors on 2 arguments and a lambda" do
-        expect {
-          node_wrap {
-            attribute(:one, :two) do |person|
-              "..."
-            end
-          }
-        }.to raise_error(ArgumentError, ERROR_MESSAGES[:attribute_lambda_one_argument])
-      end
-
-      it "errors on 1 argument since there is no inferred object" do
-        expect {
-          node_wrap {
-            attribute(:one)
-          }
-        }.to raise_error(ArgumentError, ERROR_MESSAGES[:attribute_inferred_missing_one_argument])
-      end
-
+    describe "wrapped in an object block" do
       it "renders 2 arguments statically" do
-        node = wrap { attribute(:name, "alex") }
-        node.result.should == {:name => 'alex'}
+        node = Node.new do
+          object :person do
+            attribute(:name, "alex")
+          end
+        end
+        node.result.should == {:person => {:name => 'alex'}}
       end
 
       it "renders 1 argument and one lambda with zero arity" do
-        node = wrap {
-          attribute(:name) do
-            "alex"
+        node = Node.new do
+          object :person do
+            attribute(:name) { "alex" }
           end
-        }
-        node.result.should == {:name => 'alex'}
-      end
-
-      it "errors on 1 argument and one lambda with arity 1" do
-        expect {
-          node_wrap {
-            attribute(:name) do |name|
-              name
-            end
-          }
-        }.to raise_error(ArgumentError, ERROR_MESSAGES[:attribute_inferred_missing_arity_too_large])
-      end
-
-      it "should render null attributes to null, not 'null'" do
-        node = wrap { attribute(:name, nil) }
-        node.result.should == {:name => nil}
-      end
-    end
-
-    describe "#attributes" do
-      it "errors since current_object is nil" do
-        expect {
-          node_wrap {
-            attributes(:name)
-          }
-        }.to raise_error(ArgumentError, ERROR_MESSAGES[:attributes_inferred_missing])
-      end
-    end
-  end
-
-  context "a single arg root object node" do
-
-    def wrap(&block)
-      Bldr::Node.new do
-        object(:person, &block)
-      end
-    end
-
-    describe "#attribute" do
-
-      it "errors on a single argument" do
-        expect {
-          node_wrap {
-            attribute(:one, :two) do |person|
-              "..."
-            end
-          }
-        }.to raise_error(ArgumentError, ERROR_MESSAGES[:attribute_lambda_one_argument])
-      end
-      it "errors on 3 arguments" do
-        expect {
-          node_wrap {
-            attribute(:one, :two, :three)
-          }
-        }.to raise_error(ArgumentError, ERROR_MESSAGES[:attribute_more_than_two_arg])
-      end
-      it "errors on 2 arguments and a lambda" do
-        expect {
-          node_wrap {
-            attribute(:one, :two) do |person|
-              "..."
-            end
-          }
-        }.to raise_error(ArgumentError, ERROR_MESSAGES[:attribute_lambda_one_argument])
-      end
-      it "errors on 1 argument since there is no inferred object" do
-        expect {
-          node_wrap {
-            attribute(:one)
-          }
-        }.to raise_error(ArgumentError, ERROR_MESSAGES[:attribute_inferred_missing_one_argument])
-      end
-      it "renders 2 arguments statically" do
-        node = wrap { attribute(:name, "alex") }
+        end
         node.result.should == {:person => {:name => 'alex'}}
       end
-      it "renders 1 argument and one lambda with zero arity" do
-        node = wrap {
-          attribute(:name) do
-            "alex"
-          end
-        }
-        node.result.should == {:person => {:name => 'alex'}}
-      end
-      it "errors on 1 argument and one lambda with arity 1" do
-        expect {
-          node_wrap {
-            attribute(:name) do |name|
-              name
-            end
-          }
-        }.to raise_error(ArgumentError, ERROR_MESSAGES[:attribute_inferred_missing_arity_too_large])
-      end
-    end
 
-    describe "#attributes" do
-
-      it "errors since current_object is nil" do
-        expect {
-          node_wrap {
-            attributes(:name)
-          }
-        }.to raise_error(ArgumentError, ERROR_MESSAGES[:attributes_inferred_missing])
-      end
-
-    end
-
-  end
-
-  context "a hash-arg root object node" do
-
-    def wrap(&block)
-      alex = Person.new('alex').tap { |p| p.age = 25; p }
-      Bldr::Node.new do
-        object(:person => alex, &block)
-      end
-    end
-
-    describe "#attribute" do
-      it "works at the root level" do
-        node_wrap {
-          attribute(:foo) { "bar" }
-        }.result.should == {:foo => 'bar'}
-      end
-
-      it "errors on 3 arguments" do
-        expect {
-          node_wrap {
-            attribute(:one, :two, :three)
-          }
-        }.to raise_error(ArgumentError, ERROR_MESSAGES[:attribute_more_than_two_arg])
-      end
-      it "errors on 2 arguments and a lambda" do
-        expect {
-          node_wrap {
-            attribute(:one, :two) do |person|
-              "..."
-            end
-          }
-        }.to raise_error(ArgumentError, ERROR_MESSAGES[:attribute_lambda_one_argument])
-      end
       it "renders 1 argument to the inferred object" do
-        node = wrap { attribute(:name) }
+        node = Node.new do
+          object :person => Person.new('alex', 25) do
+            attribute(:name)
+          end
+        end
         node.result.should == {:person => {:name => 'alex'}}
       end
+
       it "renders 1 argument hash to the inferred object as the different key" do
-        node = wrap { attribute(:fake => :name) }
+        # @todo remove this behavior -- it's unexpected and confusing
+        node = Node.new do
+          object :person => Person.new('alex', 25) do
+            attribute(:fake => :name)
+          end
+        end
         node.result.should == {:person => {:fake => 'alex'}}
       end
+
       it "renders 2 arguments statically" do
-        node = wrap { attribute(:name, "ian") }
+        node = Node.new do
+          object :person => Person.new('alex', 25) do
+            attribute(:name, 'ian')
+          end
+        end
         node.result.should == {:person => {:name => 'ian'}}
       end
+
       it "renders 1 argument and one lambda with zero arity" do
-        node = wrap { attribute(:name){"ian"} }
+        # @todo deprecate this behavior
+        node = Node.new do
+          object :person => Person.new('alex', 25) do
+            attribute(:name) { 'ian' }
+          end
+        end
+
         node.result.should == {:person => {:name => 'ian'}}
       end
+
       it "renders 1 argument and one lambda with arity 1" do
-        node = wrap { attribute(:name){|person| person.name} }
+        node = Node.new do
+          object :person => Person.new('alex', 25) do
+            attribute(:name) { |person| person.name }
+          end
+        end
+
         node.result.should == {:person => {:name => 'alex'}}
       end
+
       it "renders nil attributes" do
-        node = node_wrap do
+        node = Node.new do
           object :person => Person.new('alex') do
             attribute :age
           end
@@ -254,445 +121,539 @@ describe "Node#object" do
 
         node.result.should == {:person => {:age => nil}}
       end
-
     end
 
-    describe "#attributes" do
-      describe "when an object key is passed a null value" do
-        subject {
-          node = node_wrap do
-            object(:person => nil) do
-              attributes(:one, :two) do |person|
-                "..."
-              end
-            end
+    describe 'when in static key-value form (with two arguments)' do
+      it "renders 2 arguments statically as key, value" do
+        node = Node.new { attribute(:name, "alex") }
+        node.result.should == {:name => 'alex'}
+      end
+
+      it "renders null attributes to null, not 'null'" do
+        node = Node.new { attribute(:name, nil) }
+        node.result.should == {:name => nil}
+      end
+    end
+
+    describe 'when in dynamic block form (with 1 argument and a block)' do
+      it "uses the argument as the key and the block result as the value" do
+        node = Node.new {
+          attribute(:name) do
+            "alex"
           end
         }
-
-        it "does not raise an inferred object error" do
-          expect {
-            subject
-          }.not_to raise_error(ArgumentError, ERROR_MESSAGES[:attributes_inferred_missing])
-        end
-
-        its(:result) { should == {} }
+        node.result.should == {:name => 'alex'}
       end
 
-      it "renders each argument against the inferred object" do
-        node = wrap { attributes(:name, :age) }
-        node.result.should == {:person => {:name => 'alex', :age => 25}}
+      it "errors on 1 argument and one lambda with arity 1" do
+        expect {
+          Node.new {
+            attribute(:name) do |name|
+              name
+            end
+          }
+        }.to raise_error(ArgumentError, ERROR_MESSAGES[:attribute_inferred_missing_arity_too_large])
       end
-      it "renders nil attributes" do
-        node = node_wrap do
-          object :person => Person.new('alex') do
-            attributes :name, :age
-          end
-        end
-
-        node.result.should == {:person => {:name => 'alex', :age => nil}}
-      end
-
     end
 
   end
 
-  describe "embedded objects" do
-    it "evaluates the block and returns json" do
+  describe Node, "#object" do
+    context "rendering an object exactly as it exists" do
+      it "renders the object exactly as it appears when passed an object with no block" do
+        obj = {'key' => 'val', 'nested' => {'key' => 'val'}}
+        node = node_wrap do
+          object obj
+        end
+        node.result.should == obj
+      end
+    end
+
+    context "a zero arg root object node" do
+
+      def wrap(&block)
+        Bldr::Node.new do
+          object(&block)
+        end
+      end
+
+      describe "#attributes" do
+        it "errors since current_object is nil" do
+          expect {
+            node_wrap {
+              attributes(:name)
+            }
+          }.to raise_error(ArgumentError, ERROR_MESSAGES[:attributes_inferred_missing])
+        end
+      end
+    end
+
+    context "a single arg root object node" do
+
+      def wrap(&block)
+        Bldr::Node.new do
+          object(:person, &block)
+        end
+      end
+
+      describe "#attributes" do
+
+        it "errors since current_object is nil" do
+          expect {
+            node_wrap {
+              attributes(:name)
+            }
+          }.to raise_error(ArgumentError, ERROR_MESSAGES[:attributes_inferred_missing])
+        end
+      end
+    end
+
+    context "a hash-arg root object node" do
+      def wrap(&block)
+        alex = Person.new('alex').tap { |p| p.age = 25; p }
+        Bldr::Node.new do
+          object(:person => alex, &block)
+        end
+      end
+
+
+      describe "#attributes" do
+        describe "when an object key is passed a null value" do
+          subject {
+            node = node_wrap do
+              object(:person => nil) do
+                attributes(:one, :two) do |person|
+                  "..."
+                end
+              end
+            end
+          }
+
+          it "does not raise an inferred object error" do
+            expect {
+              subject
+            }.not_to raise_error(ArgumentError, ERROR_MESSAGES[:attributes_inferred_missing])
+          end
+
+          its(:result) { should == {} }
+        end
+
+        it "renders each argument against the inferred object" do
+          node = wrap { attributes(:name, :age) }
+          node.result.should == {:person => {:name => 'alex', :age => 25}}
+        end
+        it "renders nil attributes" do
+          node = node_wrap do
+            object :person => Person.new('alex') do
+              attributes :name, :age
+            end
+          end
+
+          node.result.should == {:person => {:name => 'alex', :age => nil}}
+        end
+
+      end
+
+    end
+
+    describe "embedded objects" do
+      it "evaluates the block and returns json" do
+        node = node_wrap do
+          object(:dude => Person.new("alex")) do
+            attributes :name
+
+            object(:bro => Person.new("john")) do
+              attributes :name
+            end
+          end
+        end
+
+        node.result.should == {:dude => {:name => 'alex', :bro => {:name => 'john'}}}
+      end
+    end
+
+  end
+
+  describe "Node#result" do
+    it "returns an empty hash when not passed an object" do
+      Bldr::Node.new.result.should == {}
+    end
+
+    it "a document with a single node with no nesting" do
       node = node_wrap do
-        object(:dude => Person.new("alex")) do
+        object :person => Person.new('alex') do
+          attributes :name
+        end
+      end
+
+      node.result.should == {:person => {:name => 'alex'}}
+    end
+
+    it "works for multiple top-level objects" do
+      alex, john = Person.new("alex"), Person.new("john")
+
+      node = node_wrap do
+        object(:alex => alex) do
+          attributes :name
+        end
+
+        object(:john => john) do
+          attributes :name
+        end
+      end
+
+      node.result.should == {:alex => {:name => 'alex'}, :john => {:name => 'john'}}
+    end
+
+    it "recursively renders nested objects" do
+      node = node_wrap do
+        object :alex => Person.new("alex") do
           attributes :name
 
-          object(:bro => Person.new("john")) do
+          object :friend => Person.new("john") do
             attributes :name
           end
         end
       end
 
-      node.result.should == {:dude => {:name => 'alex', :bro => {:name => 'john'}}}
-    end
-  end
-
-end
-
-describe "Node#result" do
-  it "returns an empty hash when not passed an object" do
-    Bldr::Node.new.result.should == {}
-  end
-
-  it "a document with a single node with no nesting" do
-    node = node_wrap do
-      object :person => Person.new('alex') do
-        attributes :name
-      end
+      node.result.should == {
+                             :alex => {
+                                       :name => 'alex',
+                                       :friend => {:name => 'john'}
+                                      }
+                            }
     end
 
-    node.result.should == {:person => {:name => 'alex'}}
-  end
-
-  it "works for multiple top-level objects" do
-    alex, john = Person.new("alex"), Person.new("john")
-
-    node = node_wrap do
-      object(:alex => alex) do
-        attributes :name
-      end
-
-      object(:john => john) do
-        attributes :name
-      end
-    end
-
-    node.result.should == {:alex => {:name => 'alex'}, :john => {:name => 'john'}}
-  end
-
-  it "recursively renders nested objects" do
-    node = node_wrap do
-      object :alex => Person.new("alex") do
-        attributes :name
-
-        object :friend => Person.new("john") do
-          attributes :name
+    describe "#attributes syntax" do
+      it "allows a hash to be sent where the keys are the result keys" do
+        alex = Person.new("alex").tap do |p|
+          p.age = 25
+          p
         end
+
+        node = node_wrap do
+          object(:person => alex) do
+            attributes({:surname => :name}, :age)
+          end
+        end
+
+        node.result.should == {:person => {:surname => 'alex', :age => 25}}
       end
     end
-
-    node.result.should == {
-      :alex => {
-        :name => 'alex',
-        :friend => {:name => 'john'}
-      }
-    }
   end
 
-  describe "#attributes syntax" do
-    it "allows a hash to be sent where the keys are the result keys" do
-      alex = Person.new("alex").tap do |p|
-        p.age = 25
-        p
-      end
-
+  describe Node, "#to_json" do
+    it "recursively returns the result json" do
       node = node_wrap do
-        object(:person => alex) do
-          attributes({:surname => :name}, :age)
+        object :person => Person.new("alex") do
+          attributes :name
+
+          object :friend => Person.new("pete", 30) do
+            attributes :name, :age
+          end
         end
       end
 
-      node.result.should == {:person => {:surname => 'alex', :age => 25}}
+      node.result.should == {
+                             :person => {
+                                         :name => 'alex',
+                                         :friend => {:name => 'pete', :age => 30}
+                                        }
+                            }
     end
-  end
-end
 
-describe "Node#to_json" do
-  it "recursively returns the result json" do
-    node = node_wrap do
-      object :person => Person.new("alex") do
-        attributes :name
-
-        object :friend => Person.new("pete", 30) do
+    it "returns null values for nil attributes" do
+      node = node_wrap do
+        object :person => Person.new('alex') do
           attributes :name, :age
         end
       end
-    end
 
-    node.result.should == {
-      :person => {
-        :name => 'alex',
-        :friend => {:name => 'pete', :age => 30}
-      }
-    }
+      node.result[:person].should have_key(:age)
+      node.result[:person][:age].should be_nil
+    end
   end
 
-  it "returns null values for nil attributes" do
-    node = node_wrap do
-      object :person => Person.new('alex') do
-        attributes :name, :age
-      end
-    end
-
-    node.result[:person].should have_key(:age)
-    node.result[:person][:age].should be_nil
-  end
-end
-
-describe "Node#collection" do
-  context "when passed an object with no block" do
-    it "renders the object exactly as it exists" do
-      coll = [{'key' => 'val'}]
-      node = node_wrap do
-        collection coll
-      end
-
-      node.result.should == coll
-    end
-
-    it "renders complex collection objects correctly" do
-      hobbies = [{'name' => "Gym"}, {'name' => "Tan"}, {'name' => "Laundry"}]
-
-      node = node_wrap do
-        object 'person' => Person.new("Alex") do
-          attribute :name
-          collection 'hobbies' => hobbies
+  describe Node, "#collection" do
+    context "when passed an object with no block" do
+      it "renders the object exactly as it exists" do
+        coll = [{'key' => 'val'}]
+        node = node_wrap do
+          collection coll
         end
+
+        node.result.should == coll
       end
 
-      node.result.should == {'person' => {:name => "Alex", 'hobbies' => hobbies}}
+      it "renders complex collection objects correctly" do
+        hobbies = [{'name' => "Gym"}, {'name' => "Tan"}, {'name' => "Laundry"}]
+
+        node = node_wrap do
+          object 'person' => Person.new("Alex") do
+            attribute :name
+            collection 'hobbies' => hobbies
+          end
+        end
+
+        node.result.should == {'person' => {:name => "Alex", 'hobbies' => hobbies}}
+      end
     end
-  end
 
-  it "iterates through the collection and renders them as nodes" do
-    node = node_wrap do
-      object :person => Person.new('alex', 26) do
-        attributes :name, :age
-
-        collection :friends => [Person.new('john', 24), Person.new('jeff', 25)] do
+    it "iterates through the collection and renders them as nodes" do
+      node = node_wrap do
+        object :person => Person.new('alex', 26) do
           attributes :name, :age
+
+          collection :friends => [Person.new('john', 24), Person.new('jeff', 25)] do
+            attributes :name, :age
+          end
         end
       end
+
+      node.result.should == {
+                             :person => {
+                                         :name => 'alex', :age => 26,
+                                         :friends => [{:name => 'john', :age => 24}, {:name => 'jeff', :age => 25}]
+                                        }
+                            }
     end
 
-    node.result.should == {
-      :person => {
-        :name => 'alex', :age => 26,
-        :friends => [{:name => 'john', :age => 24}, {:name => 'jeff', :age => 25}]
-      }
-    }
-  end
-
-  # @todo fix this
-  it "renders properly when a collection is the named root node" do
-    nodes = node_wrap do
-      collection :people => [Person.new('bert'), Person.new('ernie')] do
-        attributes :name
-      end
-    end
-
-    nodes.result.should == {:people => [{:name => 'bert'}, {:name => 'ernie'}]}
-  end
-
-  it "renders properly when a collection is the root node" do
-    nodes = node_wrap do
-      collection [Person.new('bert'), Person.new('ernie')] do
-        attributes :name
-      end
-    end
-
-    nodes.result.should == [{:name => 'bert'}, {:name => 'ernie'}]
-  end
-
-  it "gracefully handles empty collections" do
-    nodes = node_wrap do
-      collection :people => [] do
-        attributes :name
-      end
-    end
-
-    nodes.result.should == {:people => []}
-  end
-
-  it "gracefully handles nil collections" do
-    nodes = node_wrap do
-      collection :people => nil do
-        attributes :name
-      end
-    end
-
-    nodes.result.should == {:people => []}
-  end
-
-  it "renders nested collections properly" do
-    post = Post.new("my post")
-    post.comments << Comment.new('my comment')
-
-    nodes = node_wrap do
-      collection :posts => [post] do
-        attributes :title
-        attribute(:comment_count) { |post| post.comments.count }
-
-        collection :comments => current_object.comments do
-          attributes :body
-        end
-      end
-    end
-
-    nodes.result.should == {
-      :posts => [
-        {:title => 'my post', :comment_count => 1, :comments => [{:body => 'my comment'}]}
-      ]
-    }
-  end
-
-  it "renders objects nested in collections properly" do
-    post = Post.new 'foo'
-    post.author = Author.new('John Doe')
-    posts = [post]
-
-    nodes = node_wrap do
-      collection :data => posts do
-        attributes :title
-
-        object :author => current_object.author do
+    # @todo fix this
+    it "renders properly when a collection is the named root node" do
+      nodes = node_wrap do
+        collection :people => [Person.new('bert'), Person.new('ernie')] do
           attributes :name
         end
       end
+
+      nodes.result.should == {:people => [{:name => 'bert'}, {:name => 'ernie'}]}
     end
 
-    nodes.result.should == {
-      :data => [
-        {:title => 'foo', :author => {:name => 'John Doe'}}
-      ]
-    }
-  end
-
-  it "renders nested collections with dynamic property values correctly" do
-    post1 = Post.new("post 1")
-    post2 = Post.new("post 2")
-    post1.comments << Comment.new('post 1 comment')
-    post2.comments << Comment.new('post 2 first comment')
-    post2.comments << Comment.new('post 2 second comment')
-
-    nodes = node_wrap do
-      collection :posts => [post1, post2] do
-        attributes :title
-        attribute(:comment_count) { |post| post.comments.count }
-
-        collection :comments => current_object.comments do
-          attributes :body
+    it "renders properly when a collection is the root node" do
+      nodes = node_wrap do
+        collection [Person.new('bert'), Person.new('ernie')] do
+          attributes :name
         end
       end
+
+      nodes.result.should == [{:name => 'bert'}, {:name => 'ernie'}]
     end
 
-    nodes.result.should == {
-      :posts => [
-        {
-          :title => 'post 1',
-          :comment_count => 1,
-          :comments => [{:body => 'post 1 comment'}]
-        },
-        {
-          :title => 'post 2',
-          :comment_count => 2,
-          :comments => [{:body => 'post 2 first comment'}, {:body => 'post 2 second comment'}]
-        }
-      ]
-    }
-  end
-
-  it "allows root level attributes using local variables" do
-    node = node_wrap do
-      name = "john doe"
-      age  = 25
-
-      object do
-        attribute(:name) { name }
-        attribute(:age) { age }
+    it "gracefully handles empty collections" do
+      nodes = node_wrap do
+        collection :people => [] do
+          attributes :name
+        end
       end
+
+      nodes.result.should == {:people => []}
     end
 
-    node.result.should == {:name => 'john doe', :age => 25}
-  end
+    it "gracefully handles nil collections" do
+      nodes = node_wrap do
+        collection :people => nil do
+          attributes :name
+        end
+      end
 
-end
-
-describe "Node#template" do
-  it "includes the partial as a top level" do
-    nodes = node_wrap do
-      template "spec/fixtures/partial.json.bldr"
+      nodes.result.should == {:people => []}
     end
 
-    nodes.result.should == {:foo => "bar"}
+    it "renders nested collections properly" do
+      post = Post.new("my post")
+      post.comments << Comment.new('my comment')
+
+      nodes = node_wrap do
+        collection :posts => [post] do
+          attributes :title
+          attribute(:comment_count) { |post| post.comments.count }
+
+          collection :comments => current_object.comments do
+            attributes :body
+          end
+        end
+      end
+
+      nodes.result.should == {
+                              :posts => [
+                                         {:title => 'my post', :comment_count => 1, :comments => [{:body => 'my comment'}]}
+                                        ]
+                             }
+    end
+
+    it "renders objects nested in collections properly" do
+      post = Post.new 'foo'
+      post.author = Author.new('John Doe')
+      posts = [post]
+
+      nodes = node_wrap do
+        collection :data => posts do
+          attributes :title
+
+          object :author => current_object.author do
+            attributes :name
+          end
+        end
+      end
+
+      nodes.result.should == {
+                              :data => [
+                                        {:title => 'foo', :author => {:name => 'John Doe'}}
+                                       ]
+                             }
+    end
+
+    it "renders nested collections with dynamic property values correctly" do
+      post1 = Post.new("post 1")
+      post2 = Post.new("post 2")
+      post1.comments << Comment.new('post 1 comment')
+      post2.comments << Comment.new('post 2 first comment')
+      post2.comments << Comment.new('post 2 second comment')
+
+      nodes = node_wrap do
+        collection :posts => [post1, post2] do
+          attributes :title
+          attribute(:comment_count) { |post| post.comments.count }
+
+          collection :comments => current_object.comments do
+            attributes :body
+          end
+        end
+      end
+
+      nodes.result.should == {
+                              :posts => [
+                                         {
+                                          :title => 'post 1',
+                                          :comment_count => 1,
+                                          :comments => [{:body => 'post 1 comment'}]
+                                         },
+                                         {
+                                          :title => 'post 2',
+                                          :comment_count => 2,
+                                          :comments => [{:body => 'post 2 first comment'}, {:body => 'post 2 second comment'}]
+                                         }
+                                        ]
+                             }
+    end
+
+    it "allows root level attributes using local variables" do
+      node = node_wrap do
+        name = "john doe"
+        age  = 25
+
+        object do
+          attribute(:name) { name }
+          attribute(:age) { age }
+        end
+      end
+
+      node.result.should == {:name => 'john doe', :age => 25}
+    end
+
   end
-  
-  it "includes the partial on a top level object" do
-    nodes = node_wrap do
-      object :container do
-        attribute(:blah) { "baz" }
+
+  describe Node, "#template" do
+    it "includes the partial as a top level" do
+      nodes = node_wrap do
         template "spec/fixtures/partial.json.bldr"
       end
-    end
 
-    nodes.result.should == {:container => {:blah => "baz", :foo => "bar"}}
-  end
-  
-  it "includes the partial on a top level collection" do
-    nodes = node_wrap do
-      collection :people => [Person.new('bert'), Person.new('ernie')] do
-        attribute(:blah) { "baz" }
-        template "spec/fixtures/partial.json.bldr"
-      end
+      nodes.result.should == {:foo => "bar"}
     end
-
-    nodes.result.should == {:people => [{:blah => "baz", :foo => 'bar'}, {:blah => "baz", :foo => 'bar'}]}
-  end
-  
-  it "includes the partial on a sub object" do
-    nodes = node_wrap do
-      object :container do
-        object :sub do
+    
+    it "includes the partial on a top level object" do
+      nodes = node_wrap do
+        object :container do
           attribute(:blah) { "baz" }
           template "spec/fixtures/partial.json.bldr"
         end
       end
-    end
 
-    nodes.result.should == {:container => {:sub => {:blah => "baz", :foo => "bar"}}}
-  end
-  
-  it "includes the partial on a sub collection" do
-    nodes = node_wrap do
-      object :container do
+      nodes.result.should == {:container => {:blah => "baz", :foo => "bar"}}
+    end
+    
+    it "includes the partial on a top level collection" do
+      nodes = node_wrap do
         collection :people => [Person.new('bert'), Person.new('ernie')] do
           attribute(:blah) { "baz" }
           template "spec/fixtures/partial.json.bldr"
         end
       end
+
+      nodes.result.should == {:people => [{:blah => "baz", :foo => 'bar'}, {:blah => "baz", :foo => 'bar'}]}
+    end
+    
+    it "includes the partial on a sub object" do
+      nodes = node_wrap do
+        object :container do
+          object :sub do
+            attribute(:blah) { "baz" }
+            template "spec/fixtures/partial.json.bldr"
+          end
+        end
+      end
+
+      nodes.result.should == {:container => {:sub => {:blah => "baz", :foo => "bar"}}}
     end
 
-    nodes.result.should == {:container => {:people => [{:blah => "baz", :foo => 'bar'}, {:blah => "baz", :foo => 'bar'}]}}
-  end
-  
-  it "includes both the partials" do
-    nodes = node_wrap do
-      object :container do
-        template "spec/fixtures/partial.json.bldr"
-        object :sub do
-          attribute(:blah) { "baz" }
+    it "includes the partial on a sub collection" do
+      nodes = node_wrap do
+        object :container do
+          collection :people => [Person.new('bert'), Person.new('ernie')] do
+            attribute(:blah) { "baz" }
+            template "spec/fixtures/partial.json.bldr"
+          end
+        end
+      end
+
+      nodes.result.should == {:container => {:people => [{:blah => "baz", :foo => 'bar'}, {:blah => "baz", :foo => 'bar'}]}}
+    end
+
+    it "includes both the partials" do
+      nodes = node_wrap do
+        object :container do
           template "spec/fixtures/partial.json.bldr"
+          object :sub do
+            attribute(:blah) { "baz" }
+            template "spec/fixtures/partial.json.bldr"
+          end
+        end
+      end
+
+      nodes.result.should == {:container => {:foo => "bar", :sub => {:blah => "baz", :foo => "bar"}}}
+    end
+
+    it "includes the partial with the locals" do
+      Obj = Struct.new(:foo)
+      nodes = node_wrap do
+        template "spec/fixtures/partial_with_locals.json.bldr", :locals => {:obj => Obj.new('test')}
+      end
+
+      nodes.result.should == {:name => {:foo => 'test'}}
+    end
+
+    it "raises an error when the partial isn't found" do
+      expect {
+        nodes = node_wrap do
+          template "unknown/path"
+        end
+      }.to raise_error(Errno::ENOENT)
+    end
+
+    it "doesn't raise an error when with a base path option specified and the right file" do
+      nodes = node_wrap nil, :views => 'spec/fixtures/some' do
+        object :foo do
+          template "include"
         end
       end
     end
-
-    nodes.result.should == {:container => {:foo => "bar", :sub => {:blah => "baz", :foo => "bar"}}}
   end
-  
-  it "includes the partial with the locals" do
-    Obj = Struct.new(:foo)
-    nodes = node_wrap do
-      template "spec/fixtures/partial_with_locals.json.bldr", :locals => {:obj => Obj.new('test')}
-    end
 
-    nodes.result.should == {:name => {:foo => 'test'}}
-  end
-  
-  it "raises an error when the partial isn't found" do
-    expect {
-      nodes = node_wrap do
-        template "unknown/path"
-      end
-    }.to raise_error(Errno::ENOENT)
-  end
-  
-  it "doesn't raise an error when with a base path option specified and the right file" do
-    nodes = node_wrap nil, :views => 'spec/fixtures/some' do
-      object :foo do
-        template "include"
-      end
-    end
-  end
-end
+  describe Node, "#locals" do
+    let(:node) { Bldr::Node.new({:foo => 'bar'}, :locals => {:key => 'val'})}
+    subject { node.locals }
 
-describe "Node#locals" do
-  let(:node) { Bldr::Node.new({:foo => 'bar'}, :locals => {:key => 'val'})}
-  subject { node.locals }
-
-  it { should == {:key => 'val'} }
+    it { should == {:key => 'val'} }
+  end
 end

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -5,6 +5,7 @@ ERROR_MESSAGES = { :attribute_lambda_one_argument              => "You may only 
                   :attribute_more_than_two_arg                => "You cannot pass more than two arguments to #attribute.",
                   :attribute_inferred_missing_arity_too_large => "You cannot use a block of arity > 0 if current_object is not present.",
                   :attributes_inferred_missing                => "No current_object to apply #attributes to." }
+
 module Bldr
   describe Node, "#attributes" do
     let(:person) {
@@ -136,6 +137,11 @@ module Bldr
     end
 
     describe 'when in dynamic block form (with 1 argument and a block)' do
+      it 'sets the attribute default context to bldr node' do
+        node = Node.new { attribute(:key) { self.class } }
+        node.result[:key].should == ::Bldr::Node
+      end
+
       it "uses the argument as the key and the block result as the value" do
         node = Node.new {
           attribute(:name) do

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -165,6 +165,17 @@ module Bldr
   end
 
   describe Node, "#object" do
+    it 'is passes block the block variable to the block' do
+      denver = Person.new('John Denver')
+      node = Node.new do
+        object :person => denver do |jd|
+          attribute(:name) { jd.name }
+        end
+      end
+
+      node.result.should == {:person => {:name => 'John Denver'}}
+    end
+
     context "rendering an object exactly as it exists" do
       it "renders the object exactly as it appears when passed an object with no block" do
         obj = {'key' => 'val', 'nested' => {'key' => 'val'}}

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -567,7 +567,7 @@ module Bldr
 
       nodes.result.should == {:foo => "bar"}
     end
-    
+
     it "includes the partial on a top level object" do
       nodes = node_wrap do
         object :container do
@@ -578,7 +578,7 @@ module Bldr
 
       nodes.result.should == {:container => {:blah => "baz", :foo => "bar"}}
     end
-    
+
     it "includes the partial on a top level collection" do
       nodes = node_wrap do
         collection :people => [Person.new('bert'), Person.new('ernie')] do
@@ -589,7 +589,7 @@ module Bldr
 
       nodes.result.should == {:people => [{:blah => "baz", :foo => 'bar'}, {:blah => "baz", :foo => 'bar'}]}
     end
-    
+
     it "includes the partial on a sub object" do
       nodes = node_wrap do
         object :container do

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -405,6 +405,29 @@ module Bldr
       end
     end
 
+    it "iterates through the collection and passes each item as a block variable" do
+      denver = Person.new('John Denver')
+      songs = [Song.new('Rocky Mountain High'), Song.new('Take Me Home, Country Roads')]
+
+      node = Node.new do
+        object :artist => denver do
+          attribute :name
+
+          collection :songs => songs do |song|
+            attribute(:name) { song.name }
+          end
+        end
+      end
+
+      node.result.should == {
+                             :artist => {:name => 'John Denver',
+                                         :songs => [{:name => 'Rocky Mountain High'},
+                                                    {:name => 'Take Me Home, Country Roads'}
+                                                   ]
+                                        }
+                            }
+    end
+
     it "iterates through the collection and renders them as nodes" do
       node = node_wrap do
         object :person => Person.new('alex', 26) do
@@ -419,7 +442,9 @@ module Bldr
       node.result.should == {
                              :person => {
                                          :name => 'alex', :age => 26,
-                                         :friends => [{:name => 'john', :age => 24}, {:name => 'jeff', :age => 25}]
+                                         :friends => [
+                                                      {:name => 'john', :age => 24},
+                                                      {:name => 'jeff', :age => 25}]
                                         }
                             }
     end

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -92,7 +92,6 @@ module Bldr
       end
 
       it "renders 1 argument and one lambda with zero arity" do
-        # @todo deprecate this behavior
         node = Node.new do
           object :person => Person.new('alex', 25) do
             attribute(:name) { 'ian' }

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -505,11 +505,11 @@ module Bldr
       post.comments << Comment.new('my comment')
 
       nodes = node_wrap do
-        collection :posts => [post] do
+        collection :posts => [post] do |post|
           attributes :title
           attribute(:comment_count) { |post| post.comments.count }
 
-          collection :comments => current_object.comments do
+          collection :comments => post.comments do
             attributes :body
           end
         end
@@ -528,10 +528,10 @@ module Bldr
       posts = [post]
 
       nodes = node_wrap do
-        collection :data => posts do
+        collection :data => posts do |post|
           attributes :title
 
-          object :author => current_object.author do
+          object :author => post.author do
             attributes :name
           end
         end
@@ -552,11 +552,11 @@ module Bldr
       post2.comments << Comment.new('post 2 second comment')
 
       nodes = node_wrap do
-        collection :posts => [post1, post2] do
+        collection :posts => [post1, post2] do |post|
           attributes :title
           attribute(:comment_count) { |post| post.comments.count }
 
-          collection :comments => current_object.comments do
+          collection :comments => post.comments do
             attributes :body
           end
         end
@@ -696,5 +696,16 @@ module Bldr
     subject { node.locals }
 
     it { should == {:key => 'val'} }
+  end
+
+  describe Node, '#current_object' do
+    it 'returns the node value' do
+      Node.new('hey').current_object.should == 'hey'
+    end
+
+    it 'displays a deprecation warning' do
+      Object.any_instance.should_receive(:warn).with("[DEPRECATION] `current_object` is deprecated. Please use object or collection block varibles instead.")
+      Node.new.current_object
+    end
   end
 end

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
 ERROR_MESSAGES = { :attribute_lambda_one_argument              => "You may only pass one argument to #attribute when using the block syntax.",
-                  :attribute_inferred_missing_one_argument    => "#attribute can't be used when there is no current_object.",
-                  :attribute_more_than_two_arg                => "You cannot pass more than two arguments to #attribute.",
-                  :attribute_inferred_missing_arity_too_large => "You cannot use a block of arity > 0 if current_object is not present.",
-                  :attributes_inferred_missing                => "No current_object to apply #attributes to." }
+  :attribute_inferred_missing_one_argument    => "#attribute can't be used when there is no current_object.",
+  :attribute_more_than_two_arg                => "You cannot pass more than two arguments to #attribute.",
+  :attribute_inferred_missing_arity_too_large => "You cannot use a block of arity > 0 if current_object is not present.",
+  :attributes_inferred_missing                => "No current_object to apply #attributes to." }
 
 module Bldr
   describe Node, "#attributes" do
@@ -334,11 +334,10 @@ module Bldr
       end
 
       node.result.should == {
-                             :alex => {
-                                       :name => 'alex',
-                                       :friend => {:name => 'john'}
-                                      }
-                            }
+        :alex => {
+          :name => 'alex', :friend => {:name => 'john'}
+        }
+      }
     end
 
     describe "#attributes syntax" do
@@ -372,11 +371,11 @@ module Bldr
       end
 
       node.result.should == {
-                             :person => {
-                                         :name => 'alex',
-                                         :friend => {:name => 'pete', :age => 30}
-                                        }
-                            }
+        :person => {
+          :name => 'alex',
+          :friend => {:name => 'pete', :age => 30}
+        }
+      }
     end
 
     it "returns null values for nil attributes" do
@@ -431,12 +430,12 @@ module Bldr
       end
 
       node.result.should == {
-                             :artist => {:name => 'John Denver',
-                                         :songs => [{:name => 'Rocky Mountain High'},
-                                                    {:name => 'Take Me Home, Country Roads'}
-                                                   ]
-                                        }
-                            }
+        :artist => {:name => 'John Denver',
+          :songs => [{:name => 'Rocky Mountain High'},
+            {:name => 'Take Me Home, Country Roads'}
+          ]
+        }
+      }
     end
 
     it "iterates through the collection and renders them as nodes" do
@@ -451,13 +450,13 @@ module Bldr
       end
 
       node.result.should == {
-                             :person => {
-                                         :name => 'alex', :age => 26,
-                                         :friends => [
-                                                      {:name => 'john', :age => 24},
-                                                      {:name => 'jeff', :age => 25}]
-                                        }
-                            }
+        :person => {
+          :name => 'alex', :age => 26,
+          :friends => [
+            {:name => 'john', :age => 24},
+            {:name => 'jeff', :age => 25}]
+        }
+      }
     end
 
     # @todo fix this
@@ -517,10 +516,10 @@ module Bldr
       end
 
       nodes.result.should == {
-                              :posts => [
-                                         {:title => 'my post', :comment_count => 1, :comments => [{:body => 'my comment'}]}
-                                        ]
-                             }
+        :posts => [
+          {:title => 'my post', :comment_count => 1, :comments => [{:body => 'my comment'}]}
+        ]
+      }
     end
 
     it "renders objects nested in collections properly" do
@@ -539,10 +538,10 @@ module Bldr
       end
 
       nodes.result.should == {
-                              :data => [
-                                        {:title => 'foo', :author => {:name => 'John Doe'}}
-                                       ]
-                             }
+        :data => [
+          {:title => 'foo', :author => {:name => 'John Doe'}}
+        ]
+      }
     end
 
     it "renders nested collections with dynamic property values correctly" do
@@ -564,19 +563,19 @@ module Bldr
       end
 
       nodes.result.should == {
-                              :posts => [
-                                         {
-                                          :title => 'post 1',
-                                          :comment_count => 1,
-                                          :comments => [{:body => 'post 1 comment'}]
-                                         },
-                                         {
-                                          :title => 'post 2',
-                                          :comment_count => 2,
-                                          :comments => [{:body => 'post 2 first comment'}, {:body => 'post 2 second comment'}]
-                                         }
-                                        ]
-                             }
+        :posts => [
+          {
+            :title => 'post 1',
+            :comment_count => 1,
+            :comments => [{:body => 'post 1 comment'}]
+          },
+          {
+            :title => 'post 2',
+            :comment_count => 2,
+            :comments => [{:body => 'post 2 first comment'}, {:body => 'post 2 second comment'}]
+          }
+        ]
+      }
     end
 
     it "allows root level attributes using local variables" do


### PR DESCRIPTION
- [x] Support for inherited instance variables
- [x] Block variables for `object` and `collection` methods
- [x] Deprecation warning for `current_object`
- [x] Update readme with instructions and examples for breaking `attribute` method change and new recommended syntax instead of `current_object`
- **Deprecation:** Deprecate usage of `current_object` method with block variables for `object` and `collection` methods
- **Breaking change:** Node#attribute block syntax no longer inherits context from current_object. See 941608e7 for more.
- **Breaking change:** Drop ruby 1.8 support
