### PR TITLE
Collection & object block variables

### DIFF
--- a/lib/bldr/node.rb
+++ b/lib/bldr/node.rb
@@ -32,7 +32,13 @@ module Bldr
 
       copy_instance_variables_from(opts[:parent]) if opts[:parent]
 
-      instance_eval(&block) if block_given?
+      if block_given?
+        if value && block.arity > 0
+          instance_exec(value, &block)
+        else
+          instance_eval(&block)
+        end
+      end
     end
 
     # Create and render a node.

--- a/spec/functional/tilt_template_spec.rb
+++ b/spec/functional/tilt_template_spec.rb
@@ -4,6 +4,22 @@ module Bldr
   describe "instance variables" do
     let(:ctx) { Object.new }
 
+    describe "collection blocks" do
+      it 'has access to instance variables' do
+        ctx.instance_variable_set(:@person, Person.new("John Denver"))
+
+        Template.new do
+          <<-RUBY
+            collection :artists => [@person] do
+              attribute(:name) { @person.name }
+            end
+          RUBY
+        end.render(Node.new(nil, :parent => ctx))
+        .result
+        .should == {:artists => [{:name => 'John Denver'}]}
+      end
+    end
+
     it 'has access to instance variables in include template partials' do
       ctx.instance_variable_set(:@person, Person.new('john denver'))
 

--- a/spec/models/song.rb
+++ b/spec/models/song.rb
@@ -1,0 +1,6 @@
+class Song
+  attr_accessor :name
+  def initialize(name)
+    @name = name
+  end
+end

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -165,6 +165,17 @@ module Bldr
   end
 
   describe Node, "#object" do
+    it 'is passes block the block variable to the block' do
+      denver = Person.new('John Denver')
+      node = Node.new do
+        object :person => denver do |jd|
+          attribute(:name) { jd.name }
+        end
+      end
+
+      node.result.should == {:person => {:name => 'John Denver'}}
+    end
+
     context "rendering an object exactly as it exists" do
       it "renders the object exactly as it appears when passed an object with no block" do
         obj = {'key' => 'val', 'nested' => {'key' => 'val'}}

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -405,6 +405,29 @@ module Bldr
       end
     end
 
+    it "iterates through the collection and passes each item as a block variable" do
+      denver = Person.new('John Denver')
+      songs = [Song.new('Rocky Mountain High'), Song.new('Take Me Home, Country Roads')]
+
+      node = Node.new do
+        object :artist => denver do
+          attribute :name
+
+          collection :songs => songs do |song|
+            attribute(:name) { song.name }
+          end
+        end
+      end
+
+      node.result.should == {
+                             :artist => {:name => 'John Denver',
+                                         :songs => [{:name => 'Rocky Mountain High'},
+                                                    {:name => 'Take Me Home, Country Roads'}
+                                                   ]
+                                        }
+                            }
+    end
+
     it "iterates through the collection and renders them as nodes" do
       node = node_wrap do
         object :person => Person.new('alex', 26) do
@@ -419,7 +442,9 @@ module Bldr
       node.result.should == {
                              :person => {
                                          :name => 'alex', :age => 26,
-                                         :friends => [{:name => 'john', :age => 24}, {:name => 'jeff', :age => 25}]
+                                         :friends => [
+                                                      {:name => 'john', :age => 24},
+                                                      {:name => 'jeff', :age => 25}]
                                         }
                             }
     end

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
 ERROR_MESSAGES = { :attribute_lambda_one_argument              => "You may only pass one argument to #attribute when using the block syntax.",
-                  :attribute_inferred_missing_one_argument    => "#attribute can't be used when there is no current_object.",
-                  :attribute_more_than_two_arg                => "You cannot pass more than two arguments to #attribute.",
-                  :attribute_inferred_missing_arity_too_large => "You cannot use a block of arity > 0 if current_object is not present.",
-                  :attributes_inferred_missing                => "No current_object to apply #attributes to." }
+  :attribute_inferred_missing_one_argument    => "#attribute can't be used when there is no current_object.",
+  :attribute_more_than_two_arg                => "You cannot pass more than two arguments to #attribute.",
+  :attribute_inferred_missing_arity_too_large => "You cannot use a block of arity > 0 if current_object is not present.",
+  :attributes_inferred_missing                => "No current_object to apply #attributes to." }
 
 module Bldr
   describe Node, "#attributes" do
@@ -334,11 +334,10 @@ module Bldr
       end
 
       node.result.should == {
-                             :alex => {
-                                       :name => 'alex',
-                                       :friend => {:name => 'john'}
-                                      }
-                            }
+        :alex => {
+          :name => 'alex', :friend => {:name => 'john'}
+        }
+      }
     end
 
     describe "#attributes syntax" do
@@ -372,11 +371,11 @@ module Bldr
       end
 
       node.result.should == {
-                             :person => {
-                                         :name => 'alex',
-                                         :friend => {:name => 'pete', :age => 30}
-                                        }
-                            }
+        :person => {
+          :name => 'alex',
+          :friend => {:name => 'pete', :age => 30}
+        }
+      }
     end
 
     it "returns null values for nil attributes" do
@@ -431,12 +430,12 @@ module Bldr
       end
 
       node.result.should == {
-                             :artist => {:name => 'John Denver',
-                                         :songs => [{:name => 'Rocky Mountain High'},
-                                                    {:name => 'Take Me Home, Country Roads'}
-                                                   ]
-                                        }
-                            }
+        :artist => {:name => 'John Denver',
+          :songs => [{:name => 'Rocky Mountain High'},
+            {:name => 'Take Me Home, Country Roads'}
+          ]
+        }
+      }
     end
 
     it "iterates through the collection and renders them as nodes" do
@@ -451,13 +450,13 @@ module Bldr
       end
 
       node.result.should == {
-                             :person => {
-                                         :name => 'alex', :age => 26,
-                                         :friends => [
-                                                      {:name => 'john', :age => 24},
-                                                      {:name => 'jeff', :age => 25}]
-                                        }
-                            }
+        :person => {
+          :name => 'alex', :age => 26,
+          :friends => [
+            {:name => 'john', :age => 24},
+            {:name => 'jeff', :age => 25}]
+        }
+      }
     end
 
     # @todo fix this
@@ -517,10 +516,10 @@ module Bldr
       end
 
       nodes.result.should == {
-                              :posts => [
-                                         {:title => 'my post', :comment_count => 1, :comments => [{:body => 'my comment'}]}
-                                        ]
-                             }
+        :posts => [
+          {:title => 'my post', :comment_count => 1, :comments => [{:body => 'my comment'}]}
+        ]
+      }
     end
 
     it "renders objects nested in collections properly" do
@@ -539,10 +538,10 @@ module Bldr
       end
 
       nodes.result.should == {
-                              :data => [
-                                        {:title => 'foo', :author => {:name => 'John Doe'}}
-                                       ]
-                             }
+        :data => [
+          {:title => 'foo', :author => {:name => 'John Doe'}}
+        ]
+      }
     end
 
     it "renders nested collections with dynamic property values correctly" do
@@ -564,19 +563,19 @@ module Bldr
       end
 
       nodes.result.should == {
-                              :posts => [
-                                         {
-                                          :title => 'post 1',
-                                          :comment_count => 1,
-                                          :comments => [{:body => 'post 1 comment'}]
-                                         },
-                                         {
-                                          :title => 'post 2',
-                                          :comment_count => 2,
-                                          :comments => [{:body => 'post 2 first comment'}, {:body => 'post 2 second comment'}]
-                                         }
-                                        ]
-                             }
+        :posts => [
+          {
+            :title => 'post 1',
+            :comment_count => 1,
+            :comments => [{:body => 'post 1 comment'}]
+          },
+          {
+            :title => 'post 2',
+            :comment_count => 2,
+            :comments => [{:body => 'post 2 first comment'}, {:body => 'post 2 second comment'}]
+          }
+        ]
+      }
     end
 
     it "allows root level attributes using local variables" do


### PR DESCRIPTION
Block variables are meant to replace the `current_object` method. `current_object` **will be deprecated in 0.7.0 and removed completely in bldr 1.0.**
