### PR TITLE
object syntax to allow setting current object

### DIFF
--- a/lib/bldr/node.rb
+++ b/lib/bldr/node.rb
@@ -119,15 +119,15 @@ module Bldr
         if keyed_object?(base)
           key   = base.keys.first
           value = base.values.first
+
+          # handle nil objects
+          if value.nil?
+            merge_result!(key, nil)
+            return self
+          end
         else
           key = base
           value = nil
-        end
-
-        # handle nil objects
-        if value.nil? && keyed_object?(base)
-          merge_result!(key, nil)
-          return self
         end
 
         node  = Node.new(value, opts.merge(:parent => self), &block)

--- a/lib/bldr/node.rb
+++ b/lib/bldr/node.rb
@@ -109,6 +109,11 @@ module Bldr
     #     object :hobbies => hobbies
     #   end
     #
+    # @example Setting current object
+    #   object @person do
+    #     attributes :id, :name
+    #   end # => {'id' => 1, 'name' => 'john doe'}
+    #
     # @param [Hash, Nil] hash a key/value pair indicating the output key name
     #   and the object to serialize.
     # @param [Proc] block the code block to evaluate
@@ -126,8 +131,15 @@ module Bldr
             return self
           end
         else
-          key = base
-          value = nil
+          # e.g. set the keyspace for an object
+          if base.is_a?(Symbol) || base.is_a?(String)
+            key = base
+            value = nil
+          else
+            # e.g. set current object
+            value = base
+            key = nil
+          end
         end
 
         node  = Node.new(value, opts.merge(:parent => self), &block)

--- a/spec/functional/set_current_object_spec.rb
+++ b/spec/functional/set_current_object_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe 'setting the current object in an object block' do
+  it 'sets the object' do
+    klass = Struct.new(:name)
+    person = klass.new('alex')
+    Bldr::Node.new(nil, locals: {person: person}) do
+      object person do
+        attributes(:name)
+      end
+    end.result.should == {name: 'alex'}
+  end
+end


### PR DESCRIPTION
This change allows you to set `@current_object` with the `object` method in order to use the `attributes` method in a top-level keyspace.

``` ruby
Person = Struct.new(:name, :age, :employer)
person = Person.new('alex', 28, 'Zaarly')

object person do
  attributes :id, :name, :employer
end
```

This will output the following json document:

``` json
{
  "name": "alex",
  "age": 28,
  "employer": "Zaarly"
}
```
