### PR TITLE
add Bldr::Template.render to easily render templates outside of views

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 rvm:
   - 1.9.3
+  - 2.0.0
   - ruby-head
-  - rbx-19mode
+  - rbx

--- a/lib/bldr/template.rb
+++ b/lib/bldr/template.rb
@@ -24,6 +24,19 @@ module Bldr
     def precompiled_template(locals)
       data.to_s
     end
+
+    # Helper to render templates outside the context of a rails/sinatra view.
+    #
+    # @param [String] template path to a file name
+    # @param [Hash] opts
+    #
+    # @return [String]
+    def self.render(template, opts = {})
+      scope  = ::Bldr::Node.new
+      locals = opts.delete(:locals) || {}
+      node   = new(template, 1, opts).render(scope, locals)
+      MultiJson.encode(node.result)
+    end
   end
 
   Tilt.register 'bldr', Bldr::Template

--- a/spec/fixtures/tilt_template.bldr
+++ b/spec/fixtures/tilt_template.bldr
@@ -1,0 +1,3 @@
+object :person => person do
+  attributes :name, :age
+end

--- a/spec/functional/tilt_template_spec.rb
+++ b/spec/functional/tilt_template_spec.rb
@@ -1,6 +1,17 @@
 require 'spec_helper'
 
 module Bldr
+  describe '.template' do
+    it 'renders the template passed in' do
+      person = Person.new('jim john', 31)
+      result = Bldr::Template.render('spec/fixtures/tilt_template.bldr', locals: {person: person})
+
+      body = decode(result)
+      body['person']['name'].should == 'jim john'
+      body['person']['age'].should == 31
+    end
+  end
+
   describe 'local variable access' do
     it 'provides access to locals in nested object blocks' do
       Template.new do


### PR DESCRIPTION
A common use case is rendering a model's json when "bootstrapping" an html page so javascript classes / views can make use of the model data:

``` erb
<div class="person">
</div>

<script>
App.person = new App.Person(<%= raw(Bldr::Template.new('appointments/show', locals: {appointment: @appointment})) %>)

App.personView = new App.PersonView(model: App.person, el: '.person')
</script>
```
